### PR TITLE
CloudHv/arm: remove virtiofs driver

### DIFF
--- a/ArmVirtPkg/ArmVirtCloudHv.dsc
+++ b/ArmVirtPkg/ArmVirtCloudHv.dsc
@@ -356,7 +356,6 @@
   MdeModulePkg/Universal/Disk/UnicodeCollation/EnglishDxe/EnglishDxe.inf
   FatPkg/EnhancedFatDxe/Fat.inf
   MdeModulePkg/Universal/Disk/UdfDxe/UdfDxe.inf
-  OvmfPkg/VirtioFsDxe/VirtioFsDxe.inf
 
   #
   # Bds

--- a/ArmVirtPkg/ArmVirtCloudHv.fdf
+++ b/ArmVirtPkg/ArmVirtCloudHv.fdf
@@ -148,7 +148,6 @@ READ_LOCK_STATUS   = TRUE
   INF FatPkg/EnhancedFatDxe/Fat.inf
   INF MdeModulePkg/Universal/Disk/UnicodeCollation/EnglishDxe/EnglishDxe.inf
   INF MdeModulePkg/Universal/Disk/UdfDxe/UdfDxe.inf
-  INF OvmfPkg/VirtioFsDxe/VirtioFsDxe.inf
 
   #
   # Status Code Routing


### PR DESCRIPTION
We don't need virtiofs driver in firmware for now, and it seems
the driver in edk2 is not compatible with cloud hypervisor, thus
should be removed.

Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>