### PR TITLE
CloudHv: bump PcdCpuMaxLogicalProcessorNumber to 256

### DIFF
--- a/OvmfPkg/CloudHv/CloudHvX64.dsc
+++ b/OvmfPkg/CloudHv/CloudHvX64.dsc
@@ -623,7 +623,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdSetNxForStack|FALSE
 
   # UefiCpuPkg PCDs related to initial AP bringup and general AP management.
-  gUefiCpuPkgTokenSpaceGuid.PcdCpuMaxLogicalProcessorNumber|64
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuMaxLogicalProcessorNumber|256
   gUefiCpuPkgTokenSpaceGuid.PcdCpuBootLogicalProcessorNumber|0
 
   # Set memory encryption mask


### PR DESCRIPTION
### Problem

When using CLOUDHV.fd on cloud-hypervisor, only a total of 64 vCPUs can be used. This is because cloud-hypervisor does not (yet) implement a fw_cfg device that tells us the maximum number of logical processors and the default cloud-hypervisor config sets this value to 64. Thus, the firmware is only allocating stacks for 64 cpus. When more than 64 vcpus are in use, random vcpus crash due to stack collisions.

### Proposed solution

We should bump the default here to at least what cloud-hypervisor currently supports, that is, 254 vcpus.

I'm also open to bump this to 1024 or 8192 (the maximum number of CPUs Linux supports) because I'm working on >254 vcpu support in CHV anyway.