### PR TITLE
ci: Allow EfiLoaderData code execution in AArch64 build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,8 @@ jobs:
           source edksetup.sh
           make -C BaseTools
           export GCC5_AARCH64_PREFIX=aarch64-linux-gnu-
-          build -p ArmVirtPkg/ArmVirtCloudHv.dsc -a AARCH64 -t GCC5 -b DEBUG
+          build -p ArmVirtPkg/ArmVirtCloudHv.dsc -a AARCH64 -t GCC5 -b DEBUG \
+            --pcd gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy=0xC000000000007FD1
       - name: Upload AArch64 artifact
         if: github.event_name == 'create' && github.event.ref_type == 'tag'
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
# Description

Arm's platform configuration file in edk2 - **ArmVirt.dsc.inc** sets **PcdDxeNxMemoryProtectionPolicy** to **0xC000000000007FD5**, which marks **EfiLoaderData** allocations as **NX** aka non-executable (bit 2). This is set unconditionally for all ArmVirt platforms — both DEBUG and RELEASE builds.

During guest boot, GRUB loads its modules (filesystem drivers, boot protocol handlers, etc.) by calling Boot Services - AllocatePages() with memory type **EfiLoaderData** instead of **EfiLoaderCode**. It then executes code from these pages.

Older GRUB versions assumed data memory is executable because no firmware enforced NX on data allocations. GRUB upstream fixed this in 2017 to use the proper **EfiLoaderCode** memory type, but some distributions still ship the old behavior. Ubuntu 22.04 (Jammy) disk image we use for integration test had the older grub version.

This restriction (x86_64 does not have this security posture) was introduced to upstream **tianocore/edk2** via commit [2997ae3873](https://github.com/tianocore/edk2/commit/2997ae3873) ("ArmVirtPkg: make EFI_LOADER_DATA non-executable", 2022-08-02).

Prior to that commit, the **PCD** was **0xC000000000007FD1** which left **EfiLoaderData** executable specifically to accommodate older GRUB versions.

This PR will override the **PCD** to **0x...7FD1**  during build as documented in **ArmVirt.dsc.inc** for GRUB compatibility.

## How This Was Tested

Produced aarch64, x86_64 firmware in my fork
https://github.com/saravan2/edk2/releases/tag/aarch64-release-v2

```
saravanand@vaeq-cu2a-r118-lab-staging-hv-04:~/test-edk2$ sha256sum CLOUDHV_EFI.fd
5a5966dd01528ee55ebcf8c05b3b8a1b311d4be727ff043cfab66bf5233883ce  CLOUDHV_EFI.fd
saravanand@vaeq-cu2a-r118-lab-staging-hv-04:~/test-edk2$ cat launch-integ.sh
  sudo /home/saravanand/cloud-hypervisor/target/aarch64-unknown-linux-musl/release/cloud-hypervisor \
    --cpus boot=4 \
    --memory size=1024M \
    --kernel /home/saravanand/test-edk2/CLOUDHV_EFI.fd \
    --disk path=/home/saravanand/workloads/jammy-server-cloudimg-arm64-custom-20220329-0.raw path=/home/saravanand/test-generic-initiator/seed.img \
    --net tap=,mac=,ip=192.168.249.1,mask=255.255.255.128 \
    --serial tty \
    --console off
saravanand@vaeq-cu2a-r118-lab-staging-hv-04:~/test-edk2$ bash launch-integ.sh
-rw-rw-r--  1 saravanand saravanand 2.0M Apr  1 22:13 CLOUDHV_EFI.fd.release
-rw-rw-r--  1 saravanand saravanand 2.0M Apr  1 22:35 CLOUDHV_EFI.fd
drwxrwxr-x  2 saravanand saravanand 4.0K Apr  1 23:00 .
saravanand@vaeq-cu2a-r118-lab-staging-hv-04:~/test-edk2$ bash launch-integ.sh
cloud-hypervisor:   0.001540s: <vmm> WARN:vmm/src/device_manager.rs:2679 -- No image_type specified - detected as raw
cloud-hypervisor:   0.001567s: <vmm> WARN:vmm/src/device_manager.rs:2685 -- Autodetected raw image type. Disabling se
cloud-hypervisor:   0.001695s: <vmm> WARN:vmm/src/device_manager.rs:2679 -- No image_type specified - detected as raw
cloud-hypervisor:   0.001717s: <vmm> WARN:vmm/src/device_manager.rs:2685 -- Autodetected raw image type. Disabling se
UEFI firmware (version  built at 22:33:50 on Apr  1 2026)
add-symbol-file /home/runner/work/edk2/edk2/Build/ArmVirtCloudHv-AARCH64/DEBUG_GCC5/AARCH64/ArmPlatformPkg/Sec/Sec/DEBUG/Sec.dll 0x1800
add-symbol-file /home/runner/work/edk2/edk2/Build/ArmVirtCloudHv-AARCH64/DEBUG_GCC5/AARCH64/MdeModulePkg/Core/Pei/PeiMain/DEBUG/PeiCore.dll 0x7240
...
EFI stub: Exiting boot services...
VirtioRngExitBoot: Context=0x7E9DD818
SetUefiImageMemoryAttributes - 0x000000007F8E0000 - 0x0000000000040000 (0x0000000000000008)
SetUefiImageMemoryAttributes - 0x000000007F2B0000 - 0x0000000000040000 (0x0000000000000008)
SetUefiImageMemoryAttributes - 0x000000007F260000 - 0x0000000000040000 (0x0000000000000008)
SetUefiImageMemoryAttributes - 0x000000007F170000 - 0x0000000000040000 (0x0000000000000008)
SetUefiImageMemoryAttributes - 0x000000007F8A0000 - 0x0000000000030000 (0x0000000000000008)
SetUefiImageMemoryAttributes - 0x000000007F0E0000 - 0x0000000000030000 (0x0000000000000008)
SetUefiImageMemoryAttributes - 0x000000007EFC0000 - 0x0000000000030000 (0x0000000000000008)
[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd4f0]
[    0.000000] Linux version 5.15.0-23-generic (buildd@bos02-arm64-028) (gcc (Ubuntu 11.2.0-18ubuntu1) 11.2.0, GNU ld (GNU Binutils for Ubuntu) 2.38) #23-Ubuntu SMP Fri Mar 11 14:57:40 UTC 2022 (Ubuntu 5.15.0-23.23-generic 5.15.27)
[    0.000000] efi: EFI v2.70 by EDK II
[    0.000000] efi: ACPI 2.0=0x7f1cd018 MEMATTR=0x7e93c098 MOKvar=0x7e962000 RNG=0x7fa5d018 MEMRESERVE=0x7e9aaf18
```



