### PR TITLE
ci: Update release workflow from GCC5 to GCC toolchain

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: cloudhv-x64
-          path: Build/CloudHvX64/DEBUG_GCC5/FV/CLOUDHV.fd
+          path: Build/CloudHvX64/DEBUG_GCC/FV/CLOUDHV.fd
 
   build-aarch64:
     name: Build AArch64
@@ -51,15 +51,15 @@ jobs:
         run: |
           source edksetup.sh
           make -C BaseTools
-          export GCC5_AARCH64_PREFIX=aarch64-linux-gnu-
-          build -p ArmVirtPkg/ArmVirtCloudHv.dsc -a AARCH64 -t GCC5 -b DEBUG \
+          export GCC_AARCH64_PREFIX=aarch64-linux-gnu-
+          build -p ArmVirtPkg/ArmVirtCloudHv.dsc -a AARCH64 -t GCC -b DEBUG \
             --pcd gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy=0xC000000000007FD1
       - name: Upload AArch64 artifact
         if: github.event_name == 'create' && github.event.ref_type == 'tag'
         uses: actions/upload-artifact@v4
         with:
           name: cloudhv-aarch64
-          path: Build/ArmVirtCloudHv-AARCH64/DEBUG_GCC5/FV/CLOUDHV_EFI.fd
+          path: Build/ArmVirtCloudHv-AARCH64/DEBUG_GCC/FV/CLOUDHV_EFI.fd
 
   release:
     name: Release


### PR DESCRIPTION
# Description

The upstream edk2 project renamed the GCC5 toolchain to GCC in commits b38fea51eb and c20483b928. This caused OvmfPkg/build.sh to select the GCC toolchain, producing output in DEBUG_GCC/, while the workflow still looked for artifacts in DEBUG_GCC5/. As a result, the x86-64 build succeeded but no artifact was uploaded.

Update the AArch64 build and both artifact paths to use GCC consistently.

## How This Was Tested

I found the release workflow was broken after rebased our fork on latest edk2 stable release. See the failing workflow run: https://github.com/cloud-hypervisor/edk2/actions/runs/23925786930/job/69782177486

> Warning: No files were found with the provided path: Build/CloudHvX64/DEBUG_GCC5/FV/CLOUDHV.fd. No artifacts will be uploaded.

Now the release workflow is fixed. Example: https://github.com/likebreath/edk2/releases/tag/ch-af93bfb2ec-test


